### PR TITLE
docs: fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 ## 🛠 技術素材
 
 - HTML5
-- CSS3 (RWD 音應式設計)
+- CSS3 (RWD 響應式設計)
 - JavaScript Vanilla (無框架純純 JS)
 
 ---


### PR DESCRIPTION
## Summary
- fix a typo in the README text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684071ebc81c83318b0a539bb877a670